### PR TITLE
we're live! point to releases.hashicorp.com

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -5,7 +5,7 @@ import * as httpm from '@actions/http-client';
 import os from 'os';
 
 const DEFAULT_RELEASES_URL =
-  'http://ihngtake2gyn8nbyfgtgvu449dnsbrgopvukjdbntyndmlv7tb.s3-website-us-east-1.amazonaws.com';
+  'https://releases.hashicorp.com';
 
 interface Build {
   arch: string;


### PR DESCRIPTION
External reporter noticed that we were sourcing from an http:// URL, which was a carryover from the pre-release setup, but does have security implications.

Now Waypoint is public, we can source this from https://releases.hashicorp.com.